### PR TITLE
Examples: distinguish vector 2-norm from approx. continuous L2 norm

### DIFF
--- a/example/poisson/src/solve.cpp
+++ b/example/poisson/src/solve.cpp
@@ -34,8 +34,9 @@ PetscErrorCode solve(KSP &ksp, Mat &A, Vec &lhs, Vec &rhs, Vec &exact, Vec &err,
         KSPConvergedReason      reason; // to store the KSP convergence reason
 
         PetscInt                Niters; // iterations used to converge
+        PetscInt                N; // Vector size
 
-        PetscScalar             norm2,  // L2 norm of solution errors
+        PetscScalar             norm2,  // 2 norm of solution errors
                                 normM;  // infinity norm of solution errors
 
         ierr = KSPGetConvergedReason(ksp, &reason); CHKERRQ(ierr);
@@ -50,10 +51,11 @@ PetscErrorCode solve(KSP &ksp, Mat &A, Vec &lhs, Vec &rhs, Vec &exact, Vec &err,
         ierr = VecAXPY(err, -1.0, exact); CHKERRQ(ierr);
         ierr = VecNorm(err, NORM_2, &norm2); CHKERRQ(ierr);
         ierr = VecNorm(err, NORM_INFINITY, &normM); CHKERRQ(ierr);
+        ierr = VecGetSize(err, &N); CHKERRQ(ierr);
 
         // print infromation
         ierr = PetscPrintf(PETSC_COMM_WORLD, "\tSolve Time: %f\n", time); CHKERRQ(ierr);
-        ierr = PetscPrintf(PETSC_COMM_WORLD, "\tL2-Norm: %g\n", (double)norm2); CHKERRQ(ierr);
+        ierr = PetscPrintf(PETSC_COMM_WORLD, "\tL2-Norm: %g\n", (double)norm2/PetscSqrtReal(N)); CHKERRQ(ierr);
         ierr = PetscPrintf(PETSC_COMM_WORLD, "\tMax-Norm: %g\n", (double)normM); CHKERRQ(ierr);
         ierr = PetscPrintf(PETSC_COMM_WORLD, "\tIterations %D\n", Niters); CHKERRQ(ierr); 
 
@@ -134,8 +136,9 @@ PetscErrorCode solve(AmgXSolver &amgx, Mat &A, Vec &lhs, Vec &rhs, Vec &exact, V
         PetscFunctionBeginUser;
 
         PetscInt                Niters; // iterations used to converge
+        PetscInt                N; // Vector size
 
-        PetscScalar             norm2,  // L2 norm of solution errors
+        PetscScalar             norm2,  // 2 norm of solution errors
                                 normM;  // infinity norm of solution errors
 
         ierr = amgx.getIters(Niters); CHKERRQ(ierr);
@@ -145,10 +148,11 @@ PetscErrorCode solve(AmgXSolver &amgx, Mat &A, Vec &lhs, Vec &rhs, Vec &exact, V
         ierr = VecAXPY(err, -1.0, exact); CHKERRQ(ierr);
         ierr = VecNorm(err, NORM_2, &norm2); CHKERRQ(ierr);
         ierr = VecNorm(err, NORM_INFINITY, &normM); CHKERRQ(ierr);
+        ierr = VecGetSize(err, &N); CHKERRQ(ierr);
 
         // print infromation
         ierr = PetscPrintf(PETSC_COMM_WORLD, "\tSolve Time: %f\n", time); CHKERRQ(ierr);
-        ierr = PetscPrintf(PETSC_COMM_WORLD, "\tL2-Norm: %g\n", (double)norm2); CHKERRQ(ierr);
+        ierr = PetscPrintf(PETSC_COMM_WORLD, "\tL2-Norm: %g\n", (double)norm2/PetscSqrtReal(N)); CHKERRQ(ierr);
         ierr = PetscPrintf(PETSC_COMM_WORLD, "\tMax-Norm: %g\n", (double)normM); CHKERRQ(ierr);
         ierr = PetscPrintf(PETSC_COMM_WORLD, "\tIterations %D\n", Niters); CHKERRQ(ierr); 
 

--- a/example/solveFromFiles/src/solve.cpp
+++ b/example/solveFromFiles/src/solve.cpp
@@ -35,7 +35,7 @@ PetscErrorCode solve(KSP &ksp, Mat &A, Vec &lhs, Vec &rhs, Vec &exact, Vec &err,
 
         PetscInt                Niters; // iterations used to converge
 
-        PetscScalar             norm2,  // L2 norm of solution errors
+        PetscScalar             norm2,  // 2 norm of solution errors
                                 normM;  // infinity norm of solution errors
 
         ierr = KSPGetConvergedReason(ksp, &reason); CHKERRQ(ierr);
@@ -53,7 +53,7 @@ PetscErrorCode solve(KSP &ksp, Mat &A, Vec &lhs, Vec &rhs, Vec &exact, Vec &err,
 
         // print infromation
         ierr = PetscPrintf(PETSC_COMM_WORLD, "\tSolve Time: %f\n", time); CHKERRQ(ierr);
-        ierr = PetscPrintf(PETSC_COMM_WORLD, "\tL2-Norm: %g\n", (double)norm2); CHKERRQ(ierr);
+        ierr = PetscPrintf(PETSC_COMM_WORLD, "\t2-Norm: %g\n", (double)norm2); CHKERRQ(ierr);
         ierr = PetscPrintf(PETSC_COMM_WORLD, "\tMax-Norm: %g\n", (double)normM); CHKERRQ(ierr);
         ierr = PetscPrintf(PETSC_COMM_WORLD, "\tIterations %D\n", Niters); CHKERRQ(ierr); 
 
@@ -135,7 +135,7 @@ PetscErrorCode solve(AmgXSolver &amgx, Mat &A, Vec &lhs, Vec &rhs, Vec &exact, V
 
         PetscInt                Niters; // iterations used to converge
 
-        PetscScalar             norm2,  // L2 norm of solution errors
+        PetscScalar             norm2,  // 2 norm of solution errors
                                 normM;  // infinity norm of solution errors
 
         ierr = amgx.getIters(Niters); CHKERRQ(ierr);
@@ -148,7 +148,7 @@ PetscErrorCode solve(AmgXSolver &amgx, Mat &A, Vec &lhs, Vec &rhs, Vec &exact, V
 
         // print infromation
         ierr = PetscPrintf(PETSC_COMM_WORLD, "\tSolve Time: %f\n", time); CHKERRQ(ierr);
-        ierr = PetscPrintf(PETSC_COMM_WORLD, "\tL2-Norm: %g\n", (double)norm2); CHKERRQ(ierr);
+        ierr = PetscPrintf(PETSC_COMM_WORLD, "\t2-Norm: %g\n", (double)norm2); CHKERRQ(ierr);
         ierr = PetscPrintf(PETSC_COMM_WORLD, "\tMax-Norm: %g\n", (double)normM); CHKERRQ(ierr);
         ierr = PetscPrintf(PETSC_COMM_WORLD, "\tIterations %D\n", Niters); CHKERRQ(ierr); 
 


### PR DESCRIPTION
The Poisson discretization converges at second order in the continuous
L2 norm, but the convergence rate in the vector 2-norm depends on the
dimension of the problem.  This normalization (by vector length) yields
a norm that scales like the continuous L2 norm and thus converges at the
expected rate independent of dimension.