### PR TITLE
Add isContiguous check for new AmgX API

### DIFF
--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -3,12 +3,12 @@
 So far the, the following sets of dependencies and versions have been tested and
 worked with AmgXWrapper:
 
-#### Using AmgX GitHub Repository -- commit 3049527e0c396424df4582e837f9dd89a20f50df
+#### Using AmgX GitHub Repository -- commit aba9132119fd9efde679f41369628c04e3452a14
 
 * [OpenMPI v4.0.0](https://www.open-mpi.org/software/ompi/v4.0/)
 * [CUDA v10.0.130](https://developer.nvidia.com/cuda-10.0-download-archive)
 * [PETSc v3.10.4](https://www.mcs.anl.gov/petsc/download/index.html)
-* [AmgX GitHub commit 3049527](https://github.com/NVIDIA/AMGX/tree/3049527e0c396424df4582e837f9dd89a20f50df)
+* [AmgX GitHub commit aba9132](https://github.com/NVIDIA/AMGX/commit/aba9132119fd9efde679f41369628c04e3452a14)
 
 The C and C++ compilers for this set of dependencies are GCC 7.
 

--- a/example/poisson/src/main.cpp
+++ b/example/poisson/src/main.cpp
@@ -85,10 +85,12 @@ int main(int argc, char **argv)
                         myRank; // rank of current process
 
     PetscClassId        solvingID,
-                        warmUpID;
+                        warmUpID,
+                        setAID;
 
     PetscLogEvent       solvingEvent,
-                        warmUpEvent;
+                        warmUpEvent,
+                        setAEvent;
 
 
 
@@ -208,8 +210,10 @@ int main(int argc, char **argv)
     // register a PETSc event for warm-up and solving
     ierr = PetscClassIdRegister("SolvingClass", &solvingID); CHKERRQ(ierr);
     ierr = PetscClassIdRegister("WarmUpClass", &warmUpID); CHKERRQ(ierr);
+    ierr = PetscClassIdRegister("SetAClass", &setAID); CHKERRQ(ierr);
     ierr = PetscLogEventRegister("Solving", solvingID, &solvingEvent); CHKERRQ(ierr);
     ierr = PetscLogEventRegister("WarmUp", warmUpID, &warmUpEvent); CHKERRQ(ierr);
+    ierr = PetscLogEventRegister("setA", setAID, &setAEvent); CHKERRQ(ierr);
 
 
 
@@ -240,7 +244,9 @@ int main(int argc, char **argv)
 
 
         ierr = MPI_Barrier(PETSC_COMM_WORLD); CHKERRQ(ierr);
+        PetscLogEventBegin(setAEvent, 0, 0, 0, 0);
         ierr = amgx.setA(A); CHKERRQ(ierr);
+        PetscLogEventEnd(setAEvent, 0, 0, 0, 0);
 
         ierr = solve(amgx, A, lhs, rhs, u_exact, err, 
                 args, warmUpEvent, solvingEvent); CHKERRQ(ierr);

--- a/src/setA.cpp
+++ b/src/setA.cpp
@@ -4,12 +4,14 @@
  * \author Pi-Yueh Chuang (pychuang@gwu.edu)
  * \date 2016-01-08
  * \copyright Copyright (c) 2015-2019 Pi-Yueh Chuang, Lorena A. Barba.
+ * \copyright Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
  *            This project is released under MIT License.
  */
 
 
 // STD
 # include <cstring>
+# include <algorithm>
 
 // AmgXSolver
 # include "AmgXSolver.hpp"
@@ -28,11 +30,12 @@ PetscErrorCode AmgXSolver::setA(const Mat &A)
 
     PetscInt            nGlobalRows,
                         nLocalRows;
+    PetscBool           usesOffsets;
 
     std::vector<PetscInt>       row;
     std::vector<PetscInt64>     col;
     std::vector<PetscScalar>    data;
-    std::vector<PetscInt>       partVec;
+    std::vector<PetscInt>       partData;
 
 
     // get number of rows in global matrix
@@ -51,18 +54,29 @@ PetscErrorCode AmgXSolver::setA(const Mat &A)
     ierr = destroyLocalA(A, localA); CHK;
 
     // get a partition vector required by AmgX
-    ierr = getPartVec(devIS, nGlobalRows, partVec); CHK;
+    ierr = getPartData(devIS, nGlobalRows, partData, usesOffsets); CHK;
 
 
     // upload matrix A to AmgX
     if (gpuWorld != MPI_COMM_NULL)
     {
         ierr = MPI_Barrier(gpuWorld); CHK;
+        // offsets need to be 64 bit, since we use 64 bit column indices
+        std::vector<PetscInt64> offsets;
 
-        AMGX_matrix_upload_all_global(
+        AMGX_distribution_handle dist;
+        AMGX_distribution_create(&dist, cfg);
+        if (usesOffsets) {
+            offsets.assign(partData.begin(), partData.end());
+            AMGX_distribution_set_partition_data(dist, AMGX_DIST_PARTITION_OFFSETS, offsets.data());
+        } else {
+            AMGX_distribution_set_partition_data(dist, AMGX_DIST_PARTITION_VECTOR, partData.data());
+        }
+        AMGX_matrix_upload_distributed(
                 AmgXA, nGlobalRows, nLocalRows, row[nLocalRows],
                 1, 1, row.data(), col.data(), data.data(),
-                nullptr, ring, ring, partVec.data());
+                nullptr, dist);
+        AMGX_distribution_destroy(dist);
 
         // bind the matrix A to the solver
         ierr = MPI_Barrier(gpuWorld); CHK;
@@ -298,10 +312,41 @@ PetscErrorCode AmgXSolver::destroyLocalA(const Mat &A, Mat &localA)
     PetscFunctionReturn(0);
 }
 
+/* \implements AmgXSolver::checkForContiguousPartitioning */
+PetscErrorCode AmgXSolver::checkForContiguousPartitioning(
+    const IS &devIS, PetscBool &isContiguous, std::vector<PetscInt> &partOffsets)
+{
+    PetscFunctionBeginUser;
+    PetscErrorCode      ierr;
+    PetscBool sorted;
+    PetscInt ismax= -2; // marker for "unsorted", allows to check after global sort
 
-/* \implements AmgXSolver::getPartVec */
-PetscErrorCode AmgXSolver::getPartVec(
-        const IS &devIS, const PetscInt &N, std::vector<PetscInt> &partVec)
+    ierr = ISSorted(devIS, &sorted); CHK;
+    if (sorted)
+    {
+        ierr = ISGetMinMax(devIS, NULL, &ismax); CHK;
+    }
+    partOffsets.resize(gpuWorldSize);
+    ++ismax; // add 1 to allow reusing gathered ismax values as partition offsets for AMGX
+    MPI_Allgather(&ismax, 1, MPIU_INT, &partOffsets[0], 1, MPIU_INT, gpuWorld);
+    bool all_sorted = std::is_sorted(partOffsets.begin(), partOffsets.end())
+                        && partOffsets[0] != -1;
+    if (all_sorted)
+    {
+        partOffsets.insert(partOffsets.begin(), 0); // partition 0 always starts at 0
+        isContiguous = PETSC_TRUE;
+    }
+    else
+    {
+        isContiguous = PETSC_FALSE;
+    }
+    PetscFunctionReturn(0);
+}
+
+
+/* \implements AmgXSolver::getPartData */
+PetscErrorCode AmgXSolver::getPartData(
+        const IS &devIS, const PetscInt &N, std::vector<PetscInt> &partData, PetscBool &usesOffsets)
 {
     PetscFunctionBeginUser;
 
@@ -312,35 +357,39 @@ PetscErrorCode AmgXSolver::getPartVec(
                         tempSEQ;
 
     PetscInt            n;
-
     PetscScalar         *tempPartVec;
 
     ierr = ISGetLocalSize(devIS, &n); CHK;
 
     if (gpuWorld != MPI_COMM_NULL)
     {
-        ierr = VecCreateMPI(gpuWorld, n, N, &tempMPI); CHK;
+        // check if sorted/contiguous, then we can skip expensive scatters
+        checkForContiguousPartitioning(devIS, usesOffsets, partData);
+        if (!usesOffsets)
+        {
+            ierr = VecCreateMPI(gpuWorld, n, N, &tempMPI); CHK;
 
-        IS      is;
-        ierr = ISOnComm(devIS, gpuWorld, PETSC_USE_POINTER, &is); CHK;
-        ierr = VecISSet(tempMPI, is, (PetscScalar) myGpuWorldRank); CHK;
-        ierr = ISDestroy(&is); CHK;
+            IS      is;
+            ierr = ISOnComm(devIS, gpuWorld, PETSC_USE_POINTER, &is); CHK;
+            ierr = VecISSet(tempMPI, is, (PetscScalar) myGpuWorldRank); CHK;
+            ierr = ISDestroy(&is); CHK;
 
-        ierr = VecScatterCreateToAll(tempMPI, &scatter, &tempSEQ); CHK;
-        ierr = VecScatterBegin(scatter,
-                tempMPI, tempSEQ, INSERT_VALUES, SCATTER_FORWARD); CHK;
-        ierr = VecScatterEnd(scatter,
-                tempMPI, tempSEQ, INSERT_VALUES, SCATTER_FORWARD); CHK;
-        ierr = VecScatterDestroy(&scatter); CHK;
-        ierr = VecDestroy(&tempMPI); CHK;
+            ierr = VecScatterCreateToAll(tempMPI, &scatter, &tempSEQ); CHK;
+            ierr = VecScatterBegin(scatter,
+                    tempMPI, tempSEQ, INSERT_VALUES, SCATTER_FORWARD); CHK;
+            ierr = VecScatterEnd(scatter,
+                    tempMPI, tempSEQ, INSERT_VALUES, SCATTER_FORWARD); CHK;
+            ierr = VecScatterDestroy(&scatter); CHK;
+            ierr = VecDestroy(&tempMPI); CHK;
 
-        ierr = VecGetArray(tempSEQ, &tempPartVec); CHK;
+            ierr = VecGetArray(tempSEQ, &tempPartVec); CHK;
 
-        partVec.assign(tempPartVec, tempPartVec+N);
+            partData.assign(tempPartVec, tempPartVec+N);
 
-        ierr = VecRestoreArray(tempSEQ, &tempPartVec); CHK;
+            ierr = VecRestoreArray(tempSEQ, &tempPartVec); CHK;
 
-        ierr = VecDestroy(&tempSEQ); CHK;
+            ierr = VecDestroy(&tempSEQ); CHK;
+        }
     }
     ierr = MPI_Barrier(globalCpuWorld); CHK;
 


### PR DESCRIPTION
The new AmgX API allows passing in partition offsets instead of a full partition vector.
Perform this check using the PETSc index set API to transparently enable the optimization.
* Updated documentation (dependencies)
* Added timing to poisson example to allow verification


I verified that the optimization works on the poisson example by doing the following:

1. Compile/load all libraries: AmgX latest (with the new API),  PETSc latest (OpenMPI, GCC), CUDA 10.1
2. Compiling the poisson example using both AmgX and the PETSc build (called `ompi_gcc_opt`):
```
cd AmgXWrapper/examples/poisson && mkdir build && cd build
cmake -DPETSC_DIR=$TOOLS/petsc -DPETSC_ARCH=ompi_gcc_opt \
-DCUDA_DIR=$CUDA_HOME -DAMGX_DIR=$TOOLS/AMGX ..
make
```
3. Running on a single DGX-1V node two cases with 4 and 8 MPI ranks, i.e. 4 and 8 GPUs:
`N=400 time -p mpirun -np 4 -x N \
    bash -c "bin/poisson -caseName Test -mode AmgX_GPU -cfgFileName configs/AmgX_SolverOptions_AGG.info -Nx \$N -Ny \$N -Nz \$N -Nruns 1 -optFileName test"`
4. Got results from log file with `grep -i solving test.log -A2 | awk '{printf("%-10s%s\n",$1, $4)}'`. (the command just filters out the runtime in seconds of the regions of interest)
5. Running with the optimization turned off/on (manually, in source) gives these times, showing that the setA routine is now scaling along with the `solve` call. Scaling is not perfect as this matrix is still somewhat small, just to be able to run a quick benchmark on a single node for this PR - I've tested this separately on multi-node GPU with larger matrix sizes, too.
```
OPTIMIZATION OFF          OPTIMIZATION ON  
With np=4                 With np=4
Solving   7.6343e+00      Solving   7.6004e+00
WarmUp    7.6985e+00      WarmUp    7.6580e+00
setA      5.8078e+00      setA      4.1525e+00
----------------------    --------------------
With np=8                 With np=8   
Solving   4.8465e+00      Solving   4.8461e+00
WarmUp    4.8944e+00      WarmUp    4.8850e+00
setA      4.4951e+00      setA      2.5223e+00
--------------------      --------------------
```

I also verified that using `N_ranks > N_gpus` still works, uses the optimized path (i.e. indices are contiguous) and gets a slight speedup, though overall runtime increased (presumably due to the consolidation overhead).