### PR TITLE
New CSR API with matrix consolidation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ MESSAGE("Begin configuration")
 MESSAGE("====================================")
 
 # start generator
-PROJECT(AmgxWrapper C CXX)
+PROJECT(AmgxWrapper C CXX CUDA)
 
 # use GNU standard installation folder heirarchy
 INCLUDE(GNUInstallDirs)
@@ -192,7 +192,9 @@ SET(SOURCE
     ${SRC}/init.cpp
     ${SRC}/misc.cpp
     ${SRC}/setA.cpp
-    ${SRC}/solve.cpp)
+    ${SRC}/solve.cpp
+    ${SRC}/consolidate.cu
+)
 
 # target AmgXWrapper
 ADD_LIBRARY(AmgXWrapper ${SOURCE})

--- a/example/poisson/CMakeLists.txt
+++ b/example/poisson/CMakeLists.txt
@@ -50,7 +50,7 @@ MESSAGE("Begin configuration")
 MESSAGE("====================================")
 
 # start generator
-PROJECT(poisson C CXX)
+PROJECT(poisson C CXX CUDA)
 
 # use GNU standard installation folder heirarchy
 INCLUDE(GNUInstallDirs)
@@ -173,12 +173,14 @@ SET(SOURCE
     ${SRC}/io.cpp
     ${SRC}/solve.cpp
     ${SRC}/StructArgs.cpp
+    ${SRC}/petscToCSR.cpp
     ${SRC}/fixSingularMat.cpp
     ${AmgXWrapperSRC}/init.cpp
     ${AmgXWrapperSRC}/misc.cpp
     ${AmgXWrapperSRC}/setA.cpp
     ${AmgXWrapperSRC}/solve.cpp
-    ${AmgXWrapperSRC}/AmgXSolver.cpp)
+    ${AmgXWrapperSRC}/AmgXSolver.cpp
+    ${AmgXWrapperSRC}/consolidate.cu)
 
 INCLUDE_DIRECTORIES(
     ${PETSC_INCLUDES} 

--- a/example/poisson/README.md
+++ b/example/poisson/README.md
@@ -99,7 +99,7 @@ $ mpiexec -n 4 bin/poisson \
     the monitor and can serve as a keyword when parsing the results in post-processing.
 2. `${PATH_TO_KSP_SETTING_FILE}` is the file containing the setting to KSP solver.
 
-Note, for argument `-mode`, available options are `PETSc` and `AmgX_GPU`.
+Note, for argument `-mode`, available options are `PETSc`, `AmgX_GPU`, and `AmgX_CSR`.
 CPU version of AmgX solver is not supported.
 
 To run a test with AmgX and with 4 CPU cores plus GPUs to solve the 3D Poisson,

--- a/example/poisson/configs/AmgX_SolverOptions_Classical.info
+++ b/example/poisson/configs/AmgX_SolverOptions_Classical.info
@@ -10,7 +10,7 @@ pcgf:max_iters=10000
 pcgf:convergence=ABSOLUTE
 pcgf:tolerance=1e-8
 pcgf:norm=L2
-pcgf:print_solve_stats=0
+pcgf:print_solve_stats=1
 pcgf:monitor_residual=1
 pcgf:obtain_timings=0
 
@@ -30,7 +30,7 @@ prec:coarse_solver(c_solver)=DENSE_LU_SOLVER
 prec:dense_lu_num_rows=2
 
 prec:algorithm=CLASSICAL
-prec:selector=HMIS
+prec:selector=PMIS
 prec:interpolator=D2
 prec:strength=AHAT
 

--- a/example/poisson/src/StructArgs.cpp
+++ b/example/poisson/src/StructArgs.cpp
@@ -55,7 +55,7 @@ PetscErrorCode StructArgs::checkHelp()
         ierr = PetscPrintf(PETSC_COMM_WORLD, "Necessary Parameters:\n"); CHKERRQ(ierr);
         ierr = PetscPrintf(PETSC_COMM_WORLD, "\t-caseName [string]\n"); CHKERRQ(ierr);
         ierr = PetscPrintf(PETSC_COMM_WORLD,
-                "\t-mode [PETSc or AmgX_GPU]\n"); CHKERRQ(ierr);
+                "\t-mode [PETSc or AmgX_GPU or AmgX_CSR]\n"); CHKERRQ(ierr);
         ierr = PetscPrintf(PETSC_COMM_WORLD,
                 "\t-cfgFileName [config file for solver]\n"); CHKERRQ(ierr);
         ierr = PetscPrintf(PETSC_COMM_WORLD,

--- a/example/poisson/src/petscToCSR.cpp
+++ b/example/poisson/src/petscToCSR.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ * \file petscToCSR.cpp
+ * \brief Converts between a PETSc matrix and a raw CSR format
+ * \author Matt Martineau (NVIDIA mmartineau@nvidia.com)
+ * \date 2020-08-05
+ */
+
+// headers
+#include "petscToCSR.hpp"
+
+#include <cstring>
+
+PetscErrorCode petscToCSR(
+    Mat &A,
+    PetscInt& nRowsLocal,
+    PetscInt& nRowsGlobal,
+    PetscInt& nNz,
+    const PetscInt*& rowOffsets,
+    const PetscInt*& colIndices,
+    PetscScalar*& values,
+    double*& lhs,
+    double*& rhs,
+    Vec& lhs_petsc,
+    Vec& rhs_petsc)
+{
+    PetscFunctionBeginUser;
+
+    PetscBool done;
+    MatType type;
+    Mat localA;
+
+    // Get the Mat type
+    PetscErrorCode ierr = MatGetType(A, &type); CHKERRQ(ierr);
+
+    // Check whether the Mat type is supported
+    if (std::strcmp(type, MATSEQAIJ) == 0) // sequential AIJ
+    {
+        // Make localA point to the same memory space as A does
+        localA = A;
+    }
+    else if (std::strcmp(type, MATMPIAIJ) == 0)
+    {
+        // Get local matrix from redistributed matrix
+        ierr = MatMPIAIJGetLocalMat(A, MAT_INITIAL_MATRIX, &localA); CHKERRQ(ierr);
+    }
+    else
+    {
+        SETERRQ1(PETSC_COMM_WORLD, PETSC_ERR_ARG_WRONG,
+                 "Mat type %s is not supported!\n", type);
+    }
+
+    // Get row and column indices in compressed row format
+    ierr = MatGetRowIJ(localA, 0, PETSC_FALSE, PETSC_FALSE,
+                       &nRowsLocal, &rowOffsets, &colIndices, &done); CHKERRQ(ierr);
+
+    ierr = MatSeqAIJGetArray(localA, &values); CHKERRQ(ierr);
+
+    // Get pointers to the raw data of local vectors
+    ierr = VecGetArray(lhs_petsc, &lhs); CHKERRQ(ierr);
+    ierr = VecGetArray(rhs_petsc, &rhs); CHKERRQ(ierr);
+
+    // Calculate the number of rows in nRowsGlobal
+    ierr = MPI_Allreduce(&nRowsLocal, &nRowsGlobal, 1, MPI_INT, MPI_SUM, PETSC_COMM_WORLD); CHKERRQ(ierr);
+
+    // Store the number of non-zeros
+    nNz = rowOffsets[nRowsLocal];
+
+    PetscFunctionReturn(0);
+}

--- a/example/poisson/src/petscToCSR.hpp
+++ b/example/poisson/src/petscToCSR.hpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ * \file petscToCSR.hpp
+ * \brief Prototypes of functions in petscToCSR.cpp
+ * \author Matt Martineau (NVIDIA mmartineau@nvidia.com)
+ * \date 2020-08-05
+ */
+
+#pragma once
+
+
+
+// PETSc
+# include <petscmat.h>
+# include <petscvec.h>
+
+
+
+PetscErrorCode petscToCSR(
+    Mat &A,
+    PetscInt& nRowsLocal,
+    PetscInt& nRowsGlobal,
+    PetscInt& nNz,
+    const PetscInt*& rowOffsets,
+    const PetscInt*& colIndices,
+    PetscScalar*& values,
+    double*& lhs,
+    double*& rhs,
+    Vec& lhs_petsc,
+    Vec& rhs_petsc);

--- a/example/solveFromFiles/CMakeLists.txt
+++ b/example/solveFromFiles/CMakeLists.txt
@@ -50,7 +50,7 @@ MESSAGE("Begin configuration")
 MESSAGE("====================================")
 
 # start generator
-PROJECT(solveFromFiles C CXX)
+PROJECT(solveFromFiles C CXX CUDA)
 
 # use GNU standard installation folder heirarchy
 INCLUDE(GNUInstallDirs)
@@ -176,6 +176,7 @@ SET(SOURCE
     ${AmgXWrapperSRC}/misc.cpp
     ${AmgXWrapperSRC}/setA.cpp
     ${AmgXWrapperSRC}/solve.cpp
+    ${AmgXWrapperSRC}/consolidate.cu
     ${AmgXWrapperSRC}/AmgXSolver.cpp)
 
 INCLUDE_DIRECTORIES(

--- a/src/consolidate.cu
+++ b/src/consolidate.cu
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ * \file consolidate.cu
+ * \brief Definition of member functions related to matrix consolidation.
+ * \author Matt Martineau (mmartineau@nvidia.com)
+ * \date 2020-07-31
+ */
+
+#include <AmgXSolver.hpp>
+
+#include <numeric>
+
+/*
+    Changes local row offsets to describe the consolidated row space on
+    the root rank.
+*/
+__global__ void fixConsolidatedRowOffsets(int nLocalRows, int offset, int* rowOffsets)
+{
+    for(int i = threadIdx.x + blockIdx.x*blockDim.x; i < nLocalRows; i += blockDim.x*gridDim.x)
+    {
+        rowOffsets[i] += offset;
+    }
+}
+
+// A set of handles to the device data storing a consolidated CSR matrix
+struct ConsolidationHandles
+{
+    cudaIpcMemHandle_t rhsConsHandle;
+    cudaIpcMemHandle_t solConsHandle;
+    cudaIpcMemHandle_t rowOffsetsConsHandle;
+    cudaIpcMemHandle_t colIndicesConsHandle;
+    cudaIpcMemHandle_t valuesConsHandle;
+};
+
+/* \implements AmgXSolver::initializeConsolidation */
+PetscErrorCode AmgXSolver::initializeConsolidation(
+    const PetscInt nLocalRows,
+    const PetscInt nLocalNz,
+    const PetscScalar* values)
+{
+    PetscFunctionBeginUser;
+
+    // Check if multiple ranks are associated with a device
+    if (devWorldSize == 1)
+    {
+        consolidationStatus = ConsolidationStatus::None;
+        PetscFunctionReturn(0);
+    }
+
+    nRowsInDevWorld.resize(devWorldSize);
+    nnzInDevWorld.resize(devWorldSize);
+    rowDispls.resize(devWorldSize+1, 0);
+    nzDispls.resize(devWorldSize+1, 0);
+
+    // Fetch to all the number of local rows on each rank
+    MPI_Request req[2];
+    int ierr = MPI_Iallgather(&nLocalRows, 1, MPI_INT, nRowsInDevWorld.data(), 1, MPI_INT, devWorld, &req[0]); CHK;
+
+    // Fetch to all the number of non zeros on each rank
+    ierr = MPI_Iallgather(&nLocalNz, 1, MPI_INT, nnzInDevWorld.data(), 1, MPI_INT, devWorld, &req[1]); CHK;
+    MPI_Waitall(2, req, MPI_STATUSES_IGNORE);
+
+    // Calculate consolidate number of rows, non-zeros, and calculate row, non-zero displacements
+    nConsNz = std::accumulate(nnzInDevWorld.begin(), nnzInDevWorld.end(), 0);
+    nConsRows = std::accumulate(nRowsInDevWorld.begin(), nRowsInDevWorld.end(), 0);
+    std::partial_sum(nRowsInDevWorld.begin(), nRowsInDevWorld.end(), rowDispls.begin()+1);
+    std::partial_sum(nnzInDevWorld.begin(), nnzInDevWorld.end(), nzDispls.begin()+1);
+
+    // Consolidate the CSR matrix data from multiple ranks sharing a single GPU to a
+    // root rank, allowing multiple ranks per GPU. This allows overdecomposing the problem
+    // when there are more CPU cores than GPUs, without the inefficiences of performing
+    // the linear solve on multiple separate domains.
+    // If the data is a device pointer then use IPC handles to perform the intra-GPU
+    // copies from the allocations of different processes operating the same GPU.
+    // Opening the handles as an initialization step means it is not necessary to
+    // repeatedly call cudaIpcOpenMemHandle, which can be expensive.
+    cudaPointerAttributes att;
+    cudaError_t err = cudaPointerGetAttributes(&att, values);
+    if (err != cudaErrorInvalidValue && att.type == cudaMemoryTypeDevice)
+    {
+        ConsolidationHandles handles;
+        // The data is already on the GPU so consolidate there
+        if (gpuProc == 0)
+        {
+            // We are consolidating data that already exists on the GPU
+            CHECK(cudaMalloc((void**)&rhsCons, sizeof(PetscScalar) * nConsRows));
+            CHECK(cudaMalloc((void**)&pCons, sizeof(PetscScalar) * nConsRows));
+            CHECK(cudaMalloc((void**)&rowOffsetsCons, sizeof(PetscInt) * (nConsRows+1)));
+            CHECK(cudaMalloc((void**)&colIndicesGlobalCons, sizeof(PetscInt) * nConsNz));
+            CHECK(cudaMalloc((void**)&valuesCons, sizeof(PetscScalar) * nConsNz));
+
+            CHECK(cudaIpcGetMemHandle(&handles.rhsConsHandle, rhsCons));
+            CHECK(cudaIpcGetMemHandle(&handles.solConsHandle, pCons));
+            CHECK(cudaIpcGetMemHandle(&handles.rowOffsetsConsHandle, rowOffsetsCons));
+            CHECK(cudaIpcGetMemHandle(&handles.colIndicesConsHandle, colIndicesGlobalCons));
+            CHECK(cudaIpcGetMemHandle(&handles.valuesConsHandle, valuesCons));
+        }
+
+        MPI_Bcast(&handles, sizeof(ConsolidationHandles), MPI_BYTE, 0, devWorld);
+
+        if(gpuProc == MPI_UNDEFINED)
+        {
+            CHECK(cudaIpcOpenMemHandle((void**)&rhsCons, handles.rhsConsHandle, cudaIpcMemLazyEnablePeerAccess));
+            CHECK(cudaIpcOpenMemHandle((void**)&pCons, handles.solConsHandle, cudaIpcMemLazyEnablePeerAccess));
+            CHECK(cudaIpcOpenMemHandle((void**)&rowOffsetsCons, handles.rowOffsetsConsHandle, cudaIpcMemLazyEnablePeerAccess));
+            CHECK(cudaIpcOpenMemHandle((void**)&colIndicesGlobalCons, handles.colIndicesConsHandle, cudaIpcMemLazyEnablePeerAccess));
+            CHECK(cudaIpcOpenMemHandle((void**)&valuesCons, handles.valuesConsHandle, cudaIpcMemLazyEnablePeerAccess));
+        }
+
+        consolidationStatus = ConsolidationStatus::Device;
+    }
+    else
+    {
+        if (gpuProc == 0)
+        {
+            // The data is already on the CPU so consolidate there
+            rowOffsetsCons = new PetscInt[nConsRows+1];
+            colIndicesGlobalCons = new PetscInt[nConsNz];
+            valuesCons = new PetscScalar[nConsNz];
+            rhsCons = new PetscScalar[nConsRows];
+            pCons = new PetscScalar[nConsRows];
+        }
+
+        consolidationStatus = ConsolidationStatus::Host;
+    }
+
+    PetscFunctionReturn(0);
+}
+
+/* \implements AmgXSolver::consolidateMatrix */
+PetscErrorCode AmgXSolver::consolidateMatrix(
+    const PetscInt nLocalRows,
+    const PetscInt nLocalNz,
+    const PetscInt* rowOffsets,
+    const PetscInt* colIndicesGlobal,
+    const PetscScalar* values)
+{
+    PetscFunctionBeginUser;
+
+    // Consolidation has been previously used, must deallocate the structures
+    if (consolidationStatus != ConsolidationStatus::Uninitialized)
+    {
+        // XXX Would the maintainers be happy to include a warning message here,
+        // that makes it clear updateA should be preferentially adopted by developers
+        // if the sparsity pattern does not change? This would avoid many costs,
+        // including re-consolidation costs.
+
+        finalizeConsolidation();
+    }
+
+    // Allocate space for the structures required to consolidate
+    initializeConsolidation(nLocalRows, nLocalNz, values);
+
+    switch(consolidationStatus)
+    {
+
+    case ConsolidationStatus::None:
+    {
+        // Consolidation is not required
+        PetscFunctionReturn(0);
+    }
+    case ConsolidationStatus::Uninitialized:
+    {
+        SETERRQ(MPI_COMM_WORLD, PETSC_ERR_SUP_SYS,
+                "Attempting to consolidate before consolidation is initialized.\n");
+        break;
+    }
+    case ConsolidationStatus::Device:
+    {
+        // Copy the data to the consolidation buffer
+        CHECK(cudaMemcpy(&rowOffsetsCons[rowDispls[myDevWorldRank]], rowOffsets, sizeof(PetscInt) * nLocalRows, cudaMemcpyDefault));
+        CHECK(cudaMemcpy(&colIndicesGlobalCons[nzDispls[myDevWorldRank]], colIndicesGlobal, sizeof(PetscInt) * nLocalNz, cudaMemcpyDefault));
+        CHECK(cudaMemcpy(&valuesCons[nzDispls[myDevWorldRank]], values, sizeof(PetscScalar) * nLocalNz, cudaMemcpyDefault));
+
+        // cudaMemcpy does not block the host in the cases above, device to device copies,
+        // so sychronize with device to ensure operation is complete. Barrier on all devWorld
+        // ranks to ensure full arrays are populated before the root process uses the data.
+        CHECK(cudaDeviceSynchronize());
+        int ierr = MPI_Barrier(devWorld); CHK;
+
+        if (gpuProc == 0)
+        {
+            // Adjust merged row offsets so that they are correct for the consolidated matrix
+            for (int i = 1; i < devWorldSize; ++i)
+            {
+                int nthreads = 128;
+                int nblocks = nRowsInDevWorld[i] / nthreads + 1;
+                fixConsolidatedRowOffsets<<<nblocks, nthreads>>>(nRowsInDevWorld[i], nzDispls[i], &rowOffsetsCons[rowDispls[i]]);
+            }
+
+            // Manually add the last entry of the rowOffsets list, which is the
+            // number of non-zeros in the CSR matrix
+            CHECK(cudaMemcpy(&rowOffsetsCons[nConsRows], &nConsNz, sizeof(int), cudaMemcpyDefault));
+        }
+        else
+        {
+            // Close IPC handles and deallocate for consolidation
+            CHECK(cudaIpcCloseMemHandle(rowOffsetsCons));
+            CHECK(cudaIpcCloseMemHandle(colIndicesGlobalCons));
+        }
+
+        CHECK(cudaDeviceSynchronize());
+        break;
+    }
+    case ConsolidationStatus::Host:
+    {
+        // Gather the matrix data to the root rank for consolidation
+        MPI_Request req[3];
+        int ierr = MPI_Igatherv(rowOffsets, nLocalRows, MPI_INT, rowOffsetsCons, nRowsInDevWorld.data(), rowDispls.data(), MPI_INT, 0, devWorld, &req[0]); CHK;
+        ierr = MPI_Igatherv(colIndicesGlobal, nLocalNz, MPI_INT, colIndicesGlobalCons, nnzInDevWorld.data(), nzDispls.data(), MPI_INT, 0, devWorld, &req[1]); CHK;
+        ierr = MPI_Igatherv(values, nLocalNz, MPI_DOUBLE, valuesCons, nnzInDevWorld.data(), nzDispls.data(), MPI_DOUBLE, 0, devWorld, &req[2]); CHK;
+        MPI_Waitall(3, req, MPI_STATUSES_IGNORE);
+
+        if (gpuProc == 0)
+        {
+            // Adjust merged row offsets so that they are correct for the consolidated matrix
+            for (int j = 1; j < devWorldSize; ++j)
+            {
+                for(int i = 0; i < nRowsInDevWorld[j]; ++i)
+                {
+                    rowOffsetsCons[rowDispls[j] + i] += nzDispls[j];
+                }
+            }
+
+            // Manually add the last entry of the rowOffsets list, which is the
+            // number of non-zeros in the CSR matrix
+            rowOffsetsCons[nConsRows] = nConsNz;
+        }
+
+        break;
+    }
+    default:
+    {
+        SETERRQ(MPI_COMM_WORLD, PETSC_ERR_SUP_SYS,
+                "Incorrect consolidation status set.\n");
+        break;
+    }
+
+    }
+
+    PetscFunctionReturn(0);
+}
+
+/* \implements AmgXSolver::reconsolidateValues */
+PetscErrorCode AmgXSolver::reconsolidateValues(
+    const PetscInt nLocalNz,
+    const PetscScalar* values)
+{
+    PetscFunctionBeginUser;
+
+    switch (consolidationStatus)
+    {
+
+    case ConsolidationStatus::None:
+    {
+        // Consolidation is not required
+        PetscFunctionReturn(0);
+    }
+    case ConsolidationStatus::Uninitialized:
+    {
+        SETERRQ(MPI_COMM_WORLD, PETSC_ERR_SUP_SYS,
+                "Attempting to re-consolidate before consolidation is initialized.\n");
+        break;
+    }
+    case ConsolidationStatus::Device:
+    {
+        CHECK(cudaDeviceSynchronize());
+        int ierr = MPI_Barrier(devWorld); CHK;
+
+        // The data is already on the GPU so consolidate there
+        CHECK(cudaMemcpy(&valuesCons[nzDispls[myDevWorldRank]], values, sizeof(PetscScalar) * nLocalNz, cudaMemcpyDefault));
+
+        CHECK(cudaDeviceSynchronize());
+        ierr = MPI_Barrier(devWorld); CHK;
+
+        break;
+    }
+    case ConsolidationStatus::Host:
+    {
+        // Gather the matrix values to the root rank for consolidation
+        int ierr = MPI_Gatherv(values, nLocalNz, MPI_DOUBLE, valuesCons, nnzInDevWorld.data(), nzDispls.data(), MPI_DOUBLE, 0, devWorld); CHK;
+        break;
+    }
+    default:
+    {
+        SETERRQ(MPI_COMM_WORLD, PETSC_ERR_SUP_SYS,
+                "Incorrect consolidation status set.\n");
+        break;
+    }
+
+    }
+
+    PetscFunctionReturn(0);
+}
+
+/* \implements AmgXSolver::freeConsStructure */
+PetscErrorCode AmgXSolver::freeConsStructure()
+{
+    PetscFunctionBeginUser;
+
+    // Only the root rank maintains a consolidated structure
+    if(gpuProc == MPI_UNDEFINED)
+    {
+        PetscFunctionReturn(0);
+    }
+
+    switch(consolidationStatus)
+    {
+
+    case ConsolidationStatus::None:
+    {
+        // Consolidation is not required
+        PetscFunctionReturn(0);
+    }
+    case ConsolidationStatus::Uninitialized:
+    {
+        SETERRQ(MPI_COMM_WORLD, PETSC_ERR_SUP_SYS,
+                 "Attempting to free consolidation structures before consolidation is initialized.\n");
+        break;
+    }
+    case ConsolidationStatus::Device:
+    {
+        // Free the device allocated consolidated CSR matrix structure
+        CHECK(cudaFree(rowOffsetsCons));
+        CHECK(cudaFree(colIndicesGlobalCons));
+        break;
+    }
+    case ConsolidationStatus::Host:
+    {
+        // Free the host allocated consolidated CSR matrix structure
+        delete[] rowOffsetsCons;
+        delete[] colIndicesGlobalCons;
+        break;
+    }
+    default:
+    {
+        SETERRQ(MPI_COMM_WORLD, PETSC_ERR_SUP_SYS,
+                "Incorrect consolidation status set.\n");
+        break;
+    }
+
+    }
+
+    PetscFunctionReturn(0);
+}
+
+/* \implements AmgXSolver::finalizeConsolidation */
+PetscErrorCode AmgXSolver::finalizeConsolidation()
+{
+    PetscFunctionBeginUser;
+
+    switch(consolidationStatus)
+    {
+
+    case ConsolidationStatus::None:
+    case ConsolidationStatus::Uninitialized:
+    {
+        // Consolidation is not required or uninitialized
+        PetscFunctionReturn(0);
+    }
+    case ConsolidationStatus::Device:
+    {
+        if (gpuProc == 0)
+        {
+            // Deallocate the CSR matrix values, solution and RHS
+            CHECK(cudaFree(valuesCons));
+            CHECK(cudaFree(pCons));
+            CHECK(cudaFree(rhsCons));
+        }
+        else
+        {
+            // Close the remaining IPC memory handles
+            CHECK(cudaIpcCloseMemHandle(valuesCons));
+            CHECK(cudaIpcCloseMemHandle(pCons));
+            CHECK(cudaIpcCloseMemHandle(rhsCons));
+        }
+        break;
+    }
+    case ConsolidationStatus::Host:
+    {
+        if(gpuProc == 0)
+        {
+            delete[] valuesCons;
+            delete[] pCons;
+            delete[] rhsCons;
+        }
+        break;
+    }
+    default:
+    {
+        SETERRQ(MPI_COMM_WORLD, PETSC_ERR_SUP_SYS,
+                "Incorrect consolidation status set.\n");
+        break;
+    }
+
+    }
+
+    // Free the local GPU partitioning structures
+    if(consolidationStatus == ConsolidationStatus::Device || consolidationStatus == ConsolidationStatus::Host)
+    {
+        nRowsInDevWorld.clear();
+        nnzInDevWorld.clear();
+        rowDispls.clear();
+        nzDispls.clear();
+    }
+
+    consolidationStatus = ConsolidationStatus::Uninitialized;
+
+    PetscFunctionReturn(0);
+}

--- a/src/solve.cpp
+++ b/src/solve.cpp
@@ -101,3 +101,95 @@ PetscErrorCode AmgXSolver::solve_real(Vec &p, Vec &b)
 
     PetscFunctionReturn(0);
 }
+
+
+/* \implements AmgXSolver::solve */
+PetscErrorCode AmgXSolver::solve(PetscScalar* p, const PetscScalar* b, const int nRows)
+{
+    PetscFunctionBeginUser;
+
+    int ierr;
+
+    if (consolidationStatus == ConsolidationStatus::Device)
+    {
+        CHECK(cudaMemcpy((void**)&pCons[rowDispls[myDevWorldRank]], p, sizeof(PetscScalar) * nRows, cudaMemcpyDefault));
+        CHECK(cudaMemcpy((void**)&rhsCons[rowDispls[myDevWorldRank]], b, sizeof(PetscScalar) * nRows, cudaMemcpyDefault));
+
+        // Must synchronize here as device to device copies are non-blocking w.r.t host
+        CHECK(cudaDeviceSynchronize());
+        ierr = MPI_Barrier(devWorld); CHK;
+    }
+    else if (consolidationStatus == ConsolidationStatus::Host)
+    {
+        MPI_Request req[2];
+        ierr = MPI_Igatherv(p, nRows, MPI_DOUBLE, &pCons[rowDispls[myDevWorldRank]], nRowsInDevWorld.data(), rowDispls.data(), MPI_DOUBLE, 0, devWorld, &req[0]); CHK;
+        ierr = MPI_Igatherv(b, nRows, MPI_DOUBLE, &rhsCons[rowDispls[myDevWorldRank]], nRowsInDevWorld.data(), rowDispls.data(), MPI_DOUBLE, 0, devWorld, &req[1]); CHK;
+        MPI_Waitall(2, req, MPI_STATUSES_IGNORE);
+    }
+
+    if (gpuWorld != MPI_COMM_NULL)
+    {
+        // Upload potentially consolidated vectors to AmgX
+        if (consolidationStatus == ConsolidationStatus::None)
+        {
+            AMGX_vector_upload(AmgXP, nRows, 1, p);
+            AMGX_vector_upload(AmgXRHS, nRows, 1, b);
+        }
+        else
+        {
+            AMGX_vector_upload(AmgXP, nConsRows, 1, pCons);
+            AMGX_vector_upload(AmgXRHS, nConsRows, 1, rhsCons);
+        }
+
+        ierr = MPI_Barrier(gpuWorld); CHK;
+
+        // Solve
+        AMGX_solver_solve(solver, AmgXRHS, AmgXP);
+
+        // Get the status of the solver
+        AMGX_SOLVE_STATUS   status;
+        AMGX_solver_get_status(solver, &status);
+
+        // Check whether the solver successfully solved the problem
+        if (status != AMGX_SOLVE_SUCCESS)
+                SETERRQ1(globalCpuWorld,
+                        PETSC_ERR_CONV_FAILED, "AmgX solver failed to solve the system! "
+                                                "The error code is %d.\n",
+                        status);
+
+        // Download data from device
+        if (consolidationStatus == ConsolidationStatus::None)
+        {
+            AMGX_vector_download(AmgXP, p);
+        }
+        else
+        {
+            AMGX_vector_download(AmgXP, pCons);
+
+            // AMGX_vector_download invokes a device to device copy here, so it is essential that
+            // the root rank blocks the host before other ranks copy from the consolidated solution
+            CHECK(cudaDeviceSynchronize());
+        }
+    }
+
+    // If the matrix is consolidated, scatter the
+    if (consolidationStatus == ConsolidationStatus::Device)
+    {
+        // Must synchronise before each rank attempts to read from the consolidated solution
+        ierr = MPI_Barrier(devWorld); CHK;
+
+        CHECK(cudaMemcpy((void **)p, &pCons[rowDispls[myDevWorldRank]], sizeof(PetscScalar) * nRows, cudaMemcpyDefault));
+        CHECK(cudaDeviceSynchronize());
+    }
+    else if (consolidationStatus == ConsolidationStatus::Host)
+    {
+        // Must synchronise before each rank attempts to read from the consolidated solution
+        ierr = MPI_Barrier(devWorld); CHK;
+
+        ierr = MPI_Scatterv(&pCons[rowDispls[myDevWorldRank]], nRowsInDevWorld.data(), rowDispls.data(), MPI_DOUBLE, p, nRows, MPI_DOUBLE, 0, devWorld); CHK;
+    }
+
+    ierr = MPI_Barrier(globalCpuWorld); CHK;
+
+    PetscFunctionReturn(0);
+}


### PR DESCRIPTION
This change adds new public API calls:

 - An overload of setA that accepts raw CSR inputs and uploads a matrix to AmgX, and sets up the solver/preconditioner
 - A new updateA that accepts raw CSR inputs and replaces the coefficients, and re-sets up the solver/preconditioner
    - for cases where the matrix coefficients change between solves, this is significantly more efficient than calling setA again
 - An overload of solve that accepts raw CSR inputs and honours the matrix consolidation

A corresponding example mode has been added to examples/poisson that demonstrates the use of this API extension. Importantly, the new routines can be called using either host or device pointers. Further, they will maintain the functionality of the original APIs in that multiple host processes can be consolidated to a single GPU. If device pointers are passed into the new routines the consolidation feature uses cudaIPC calls to perform a low overhead merging of the matrices to be passed into AmgX.

I have tried to match the original coding style and general approach, but am ready to iterate and change as necessary to match your requirements. Also, there are some issues that I wanted to ask your opinion on: 

 - The minimum version of CMake for CUDA is 3.8 - would you be happy to upgrade the minimum required version to accept this change?
 - I use raw host/device pointers for the consolidation data. This could be replaced with unique_ptr or thrust::device_ptr if you would be more comfortable with managed pointers.

Note that I also have some ideas for future extensions and optimisations if this pull request proves successful.